### PR TITLE
Update DebdebSystem to PromisedWorlds to match v1.0.1+

### DIFF
--- a/SpaceDustNext/Definitions/Promised Worlds/Axod
+++ b/SpaceDustNext/Definitions/Promised Worlds/Axod
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdHe3
 	body = Axod
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdDeuterium
 	body = Axod
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdHydrogen
 	body = Axod
@@ -127,7 +127,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdDeuterium
 	body = Axod
@@ -170,7 +170,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdHydrogen
 	body = Axod
@@ -213,7 +213,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdMethane
 	body = Axod
@@ -256,7 +256,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdAmmonia
 	body = Axod
@@ -299,7 +299,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = Water
 	body = Axod

--- a/SpaceDustNext/Definitions/Promised Worlds/Charr.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Charr.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
   resourceName = LqdHe3
   body = Charr
@@ -34,7 +34,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	latFalloffType = None
   }
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
   resourceName = Rock
   body = Charr
@@ -70,7 +70,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	latFalloffType = Linear
   }
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdCO2
 	body = Charr

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
   resourceName = LqdHydrogen
   body = Debdeb
@@ -64,7 +64,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	latFalloffType = None
   }
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
   resourceName = LqdHe3
   body = Debdeb
@@ -100,7 +100,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	latFalloffType = None
   }
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
   resourceName = LqdDeuterium
   body = Debdeb

--- a/SpaceDustNext/Definitions/Promised Worlds/Donk.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Donk.cfg
@@ -1,110 +1,22 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
-{
-	resourceName = LqdHe3
-	body = Rosh
-	
-	RESOURCEBAND
-	{
-		name = roshAtmo
-		title = #LOC_SpaceDust_Band_Atmosphere
-		
-		minAbundance = 0.0000000918
-		maxAbundance = 0.0000000918
-		
-		alwaysDiscovered = false
-		alwaysIdentified = false
-		
-		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 25
-	        identifyScienceReward = 25
-		
-		useAirDensity = True
-		densityCurve
-		{
-			key = 0 0
-			key = 1 1
-			key = 12 12
-		}
-		distributionType = Spherical
-		
-		altUpperBound = 10000
-		altLowerBound = -500
-		altPeak = 0
-		altVariability = 0
-		altFalloffType = Linear
-		
-		latUpperBound = 90
-		latLowerBound = -90
-		latPeak = 0
-		latVariability = 0
-		latFalloffType = None
-	}
-}
-
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
-{
-	resourceName = LiquidFuel
-	body = Rosh
-	
-	RESOURCEBAND
-	{
-		name = roshAtmo
-		title = #LOC_SpaceDust_Band_Atmosphere
-		
-		minAbundance = 1.0125
-		maxAbundance = 1.05
-  		@minAbundance *= #$/refLqdMethane$
-		@maxAbundance *= #$/refLqdMethane$
-		
-		alwaysDiscovered = false
-		alwaysIdentified = false
-		
-		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 10
-	        identifyScienceReward = 10
-		
-		useAirDensity = True
-		densityCurve
-		{
-			key = 0 0
-			key = 1 1
-			key = 12 12
-		}
-		distributionType = Spherical
-		
-		altUpperBound = 10000
-		altLowerBound = -500
-		altPeak = 0
-		altVariability = 0
-		altFalloffType = Linear
-		
-		latUpperBound = 90
-		latLowerBound = -90
-		latPeak = 0
-		latVariability = 0
-		latFalloffType = None
-	}
-}
-
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdCO2
-	body = Rosh
+	body = Donk
 	
 	RESOURCEBAND
 	{
-		name = roshAtmo
-		title = #LOC_SpaceDust_Band_LowAtmosphere
+		name = donkAtmo
+		title = #LOC_SpaceDust_Band_Atmosphere
 		
-		minAbundance = 0.000306
-		maxAbundance = 0.000306
+		minAbundance = 1.1
+		maxAbundance = 1.0
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
 		remoteDiscoveryScale = 0.1
 		discoveryScienceReward = 10
-	        identifyScienceReward = 10
+	    identifyScienceReward = 10		
 		
 		useAirDensity = True
 		densityCurve
@@ -112,11 +24,11 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 			key = 0 0
 			key = 1 1
 			key = 12 12
-		}
+		}		
 		distributionType = Spherical
 		
-		altUpperBound = 10000
-		altLowerBound = -500
+		altUpperBound = 44000
+		altLowerBound = 0
 		altPeak = 0
 		altVariability = 0
 		altFalloffType = Linear
@@ -127,5 +39,84 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		latVariability = 0
 		latFalloffType = None
 	}
+}
 
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+{
+	resourceName = ArgonGas
+	body = Donk
+	
+	RESOURCEBAND
+	{
+		name = donkAtmo
+		title = #LOC_SpaceDust_Band_Atmosphere
+		
+		minAbundance = 0.0000038
+		maxAbundance = 0.0000072
+		
+		alwaysDiscovered = false
+		alwaysIdentified = false
+		
+		remoteDiscoveryScale = 0.1
+		discoveryScienceReward = 15
+	    identifyScienceReward = 15	
+		
+		useAirDensity = True
+		densityCurve
+		{
+			key = 0 0
+			key = 1 1
+			key = 12 12
+		}		
+		distributionType = Spherical
+		
+		altUpperBound = 44000
+		altLowerBound = 0
+		altPeak = 0
+		altVariability = 0
+		altFalloffType = Linear
+		
+		latUpperBound = 90
+		latLowerBound = -90
+		latPeak = 0
+		latVariability = 0
+		latFalloffType = None
+	}
+}
+
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+{
+	resourceName = Antimatter
+	body = Donk
+
+	RESOURCEBAND
+	{
+		name = donkExo
+		title = #LOC_SpaceDust_Band_Exosphere
+
+		minAbundance = 4.10E-19
+		maxAbundance = 8.05E-19
+		
+		alwaysDiscovered = false
+		alwaysIdentified = false
+		
+		remoteDiscoveryScale = 0.001
+		discoveryScienceReward = 50
+	    identifyScienceReward = 50		
+
+		useAirDensity = False
+		distributionType = Spherical
+
+		altUpperBound = 50000
+		altLowerBound = 45000
+		altPeak = 0
+		altVariability = 10
+		altFalloffType = Linear
+
+		latUpperBound = 90
+		latLowerBound = -90
+		latPeak = 0
+		latVariability = 0
+		latFalloffType = None
+	}
 }

--- a/SpaceDustNext/Definitions/Promised Worlds/Dorau.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Dorau.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdNitrogen
 	body = Dorau
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdCO2
 	body = Dorau
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdAmmonia
 	body = Dorau

--- a/SpaceDustNext/Definitions/Promised Worlds/Glumo
+++ b/SpaceDustNext/Definitions/Promised Worlds/Glumo
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdHe3
 	body = Glumo
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdDeuterium
 	body = Glumo
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdHydrogen
 	body = Glumo
@@ -127,7 +127,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdHydrogen
 	body = Glumo
@@ -164,7 +164,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdDeuterium
 	body = Glumo
@@ -201,7 +201,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdMethane
 	body = Glumo
@@ -244,7 +244,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = Water
 	body = Glumo
@@ -287,7 +287,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = Antimatter
 	body = Glumo

--- a/SpaceDustNext/Definitions/Promised Worlds/Gurdamma.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Gurdamma.cfg
@@ -1,22 +1,22 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdCO2
-	body = Ovin
+	body = Gurdamma
 	
 	RESOURCEBAND
 	{
-		name = ovinAtmo
+		name = gurdammaAtmo
 		title = #LOC_SpaceDust_Band_Atmosphere
 		
-		minAbundance = 1.0
-		maxAbundance = 1.1
+		minAbundance = 0.000276
+		maxAbundance = 0.000306
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
 		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 10
-	    identifyScienceReward = 10
+		discoveryScienceReward = 25
+	        identifyScienceReward = 25
 		
 		useAirDensity = True
 		densityCurve
@@ -27,7 +27,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		}
 		distributionType = Spherical
 		
-		altUpperBound = 32000
+		altUpperBound = 74000
 		altLowerBound = -500
 		altPeak = 0
 		altVariability = 0
@@ -41,25 +41,25 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdNitrogen
-	body = Ovin
+	body = Gurdamma
 	
 	RESOURCEBAND
 	{
-		name = ovinAtmo
+		name = gurdammaAtmo
 		title = #LOC_SpaceDust_Band_Atmosphere
 		
-		minAbundance = 0.00125
-		maxAbundance = 0.01
+		minAbundance = 1.0125
+		maxAbundance = 1.05
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
 		remoteDiscoveryScale = 0.1
 		discoveryScienceReward = 10
-	    identifyScienceReward = 10
+	        identifyScienceReward = 10
 		
 		useAirDensity = True
 		densityCurve
@@ -70,7 +70,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		}
 		distributionType = Spherical
 		
-		altUpperBound = 32000
+		altUpperBound = 74000
 		altLowerBound = -500
 		altPeak = 0
 		altVariability = 0
@@ -84,25 +84,25 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = Water
-	body = Ovin
+	body = Gurdamma
 	
 	RESOURCEBAND
 	{
-		name = ovinAtmo
+		name = gurdammaAtmo
 		title = #LOC_SpaceDust_Band_LowAtmosphere
 		
-		minAbundance = 0.000007
-		maxAbundance = 0.000007
+		minAbundance = 0.0007
+		maxAbundance = 0.0007
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
 		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 15
-	    identifyScienceReward = 15
+		discoveryScienceReward = 10
+	        identifyScienceReward = 10
 		
 		useAirDensity = True
 		densityCurve
@@ -113,7 +113,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		}
 		distributionType = Spherical
 		
-		altUpperBound = 5000
+		altUpperBound = 10000
 		altLowerBound = -500
 		altPeak = 0
 		altVariability = 0
@@ -126,62 +126,88 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		latFalloffType = None
 	}
 }
-
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
-	resourceName = ArgonGas
-	body = Ovin
+	resourceName = Antimatter
+	body = Gurdamma
 	
 	RESOURCEBAND
 	{
-		name = ovinAtmo
-		title = #LOC_SpaceDust_Band_Atmosphere
+		name = gurdammaRing
+		title = #LOC_SpaceDust_Band_LowBelt
 		
-		minAbundance = 0.0000038
-		maxAbundance = 0.0000072
+		minAbundance = 4.10E-20
+		maxAbundance = 8.05E-20
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
-		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 15
-	    identifyScienceReward = 15
+		remoteDiscoveryScale = 0.001
+		discoveryScienceReward = 50
+	        identifyScienceReward = 50
 		
-		useAirDensity = True
-		densityCurve
-		{
-			key = 0 0
-			key = 1 1
-			key = 12 12
-		}
+		useAirDensity = False
 		distributionType = Spherical
 		
-		altUpperBound = 32000
-		altLowerBound = -500
-		altPeak = 0
+		altUpperBound = 500000
+		altLowerBound = 260000
+		altPeak = 390000
+		altVariability = 10
+		altFalloffType = Linear
+		
+		latUpperBound = 30
+		latLowerBound = -30
+		latPeak = 0
+		latVariability = 1
+		latFalloffType = None
+	}
+	RESOURCEBAND
+	{
+		name = donkAreaRing
+		title = #LOC_SpaceDust_Band_Ring
+		
+		minAbundance = 4.10E-18
+		maxAbundance = 8.05E-18
+		
+		countScale = 20
+		rotateRate = 0.25
+		
+		alwaysDiscovered = false
+		alwaysIdentified = false
+		
+		remoteDiscoveryScale = 0.001
+		discoveryScienceReward = 50
+	        identifyScienceReward = 50
+		
+		useAirDensity = False
+		distributionType = Spherical
+		
+		altUpperBound = 1940000
+		altLowerBound = 1700000
+		altPeak = 1820000
 		altVariability = 0
 		altFalloffType = Linear
 		
-		latUpperBound = 90
-		latLowerBound = -90
+		latUpperBound = 1
+		latLowerBound = -1
 		latPeak = 0
 		latVariability = 0
 		latFalloffType = None
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdHydrogen
-	body = Ovin
+	body = Gurdamma
 	
 	RESOURCEBAND
 	{
-		name = ovinExo
+		name = gurdammaExo
 		title = #LOC_SpaceDust_Band_Exosphere
 		
-		minAbundance = 1.11E-21
-		maxAbundance = 7.03E-22
+		minAbundance = 1.11E-19
+		maxAbundance = 7.03E-20
 		
 		countScale = 50
 		rotateRate = 1

--- a/SpaceDustNext/Definitions/Promised Worlds/Lapat.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Lapat.cfg
@@ -1,22 +1,22 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
-	resourceName = LqdCO2
-	body = Donk
+	resourceName = Oxidizer
+	body = Lapat
 	
 	RESOURCEBAND
 	{
-		name = donkAtmo
+		name = lapatAtmo
 		title = #LOC_SpaceDust_Band_Atmosphere
 		
-		minAbundance = 1.1
-		maxAbundance = 1.0
+		minAbundance = 0.000306
+		maxAbundance = 0.000306
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
 		remoteDiscoveryScale = 0.1
 		discoveryScienceReward = 10
-	    identifyScienceReward = 10		
+	        identifyScienceReward = 10
 		
 		useAirDensity = True
 		densityCurve
@@ -24,11 +24,11 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 			key = 0 0
 			key = 1 1
 			key = 12 12
-		}		
+		}
 		distributionType = Spherical
 		
-		altUpperBound = 44000
-		altLowerBound = 0
+		altUpperBound = 97000
+		altLowerBound = -500
 		altPeak = 0
 		altVariability = 0
 		altFalloffType = Linear
@@ -41,25 +41,25 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
-	resourceName = ArgonGas
-	body = Donk
+	resourceName = LqdNitrogen
+	body = Lapat
 	
 	RESOURCEBAND
 	{
-		name = donkAtmo
+		name = lapatAtmo
 		title = #LOC_SpaceDust_Band_Atmosphere
 		
-		minAbundance = 0.0000038
-		maxAbundance = 0.0000072
+		minAbundance = 1.0125
+		maxAbundance = 1.05
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
 		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 15
-	    identifyScienceReward = 15	
+		discoveryScienceReward = 10
+	        identifyScienceReward = 10
 		
 		useAirDensity = True
 		densityCurve
@@ -67,11 +67,11 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 			key = 0 0
 			key = 1 1
 			key = 12 12
-		}		
+		}
 		distributionType = Spherical
 		
-		altUpperBound = 44000
-		altLowerBound = 0
+		altUpperBound = 97000
+		altLowerBound = -500
 		altPeak = 0
 		altVariability = 0
 		altFalloffType = Linear
@@ -84,35 +84,41 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
-	resourceName = Antimatter
-	body = Donk
-
+	resourceName = Water
+	body = Lapat
+	
 	RESOURCEBAND
 	{
-		name = donkExo
-		title = #LOC_SpaceDust_Band_Exosphere
-
-		minAbundance = 4.10E-19
-		maxAbundance = 8.05E-19
+		name = lapatAtmo
+		title = #LOC_SpaceDust_Band_LowAtmosphere
+		
+		minAbundance = 0.0007
+		maxAbundance = 0.0007
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
-		remoteDiscoveryScale = 0.001
-		discoveryScienceReward = 50
-	    identifyScienceReward = 50		
-
-		useAirDensity = False
+		remoteDiscoveryScale = 0.1
+		discoveryScienceReward = 10
+	        identifyScienceReward = 10
+		
+		useAirDensity = True
+		densityCurve
+		{
+			key = 0 0
+			key = 1 1
+			key = 12 12
+		}
 		distributionType = Spherical
-
-		altUpperBound = 50000
-		altLowerBound = 45000
+		
+		altUpperBound = 97000
+		altLowerBound = -500
 		altPeak = 0
-		altVariability = 10
+		altVariability = 0
 		altFalloffType = Linear
-
+		
 		latUpperBound = 90
 		latLowerBound = -90
 		latPeak = 0

--- a/SpaceDustNext/Definitions/Promised Worlds/Merbel.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Merbel.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LiquidFuel
 	body = Merbel
@@ -43,7 +43,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdNitrogen
 	body = Merbel
@@ -86,7 +86,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdCO2
 	body = Merbel

--- a/SpaceDustNext/Definitions/Promised Worlds/Ovin.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Ovin.cfg
@@ -1,22 +1,22 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdCO2
-	body = Gurdamma
+	body = Ovin
 	
 	RESOURCEBAND
 	{
-		name = gurdammaAtmo
+		name = ovinAtmo
 		title = #LOC_SpaceDust_Band_Atmosphere
 		
-		minAbundance = 0.000276
-		maxAbundance = 0.000306
+		minAbundance = 1.0
+		maxAbundance = 1.1
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
 		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 25
-	        identifyScienceReward = 25
+		discoveryScienceReward = 10
+	    identifyScienceReward = 10
 		
 		useAirDensity = True
 		densityCurve
@@ -27,7 +27,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		}
 		distributionType = Spherical
 		
-		altUpperBound = 74000
+		altUpperBound = 32000
 		altLowerBound = -500
 		altPeak = 0
 		altVariability = 0
@@ -41,25 +41,25 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdNitrogen
-	body = Gurdamma
+	body = Ovin
 	
 	RESOURCEBAND
 	{
-		name = gurdammaAtmo
+		name = ovinAtmo
 		title = #LOC_SpaceDust_Band_Atmosphere
 		
-		minAbundance = 1.0125
-		maxAbundance = 1.05
+		minAbundance = 0.00125
+		maxAbundance = 0.01
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
 		remoteDiscoveryScale = 0.1
 		discoveryScienceReward = 10
-	        identifyScienceReward = 10
+	    identifyScienceReward = 10
 		
 		useAirDensity = True
 		densityCurve
@@ -70,7 +70,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		}
 		distributionType = Spherical
 		
-		altUpperBound = 74000
+		altUpperBound = 32000
 		altLowerBound = -500
 		altPeak = 0
 		altVariability = 0
@@ -84,25 +84,25 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = Water
-	body = Gurdamma
+	body = Ovin
 	
 	RESOURCEBAND
 	{
-		name = gurdammaAtmo
+		name = ovinAtmo
 		title = #LOC_SpaceDust_Band_LowAtmosphere
 		
-		minAbundance = 0.0007
-		maxAbundance = 0.0007
+		minAbundance = 0.000007
+		maxAbundance = 0.000007
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
 		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 10
-	        identifyScienceReward = 10
+		discoveryScienceReward = 15
+	    identifyScienceReward = 15
 		
 		useAirDensity = True
 		densityCurve
@@ -113,7 +113,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		}
 		distributionType = Spherical
 		
-		altUpperBound = 10000
+		altUpperBound = 5000
 		altLowerBound = -500
 		altPeak = 0
 		altVariability = 0
@@ -126,88 +126,62 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		latFalloffType = None
 	}
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
-	resourceName = Antimatter
-	body = Gurdamma
+	resourceName = ArgonGas
+	body = Ovin
 	
 	RESOURCEBAND
 	{
-		name = gurdammaRing
-		title = #LOC_SpaceDust_Band_LowBelt
+		name = ovinAtmo
+		title = #LOC_SpaceDust_Band_Atmosphere
 		
-		minAbundance = 4.10E-20
-		maxAbundance = 8.05E-20
-		
-		alwaysDiscovered = false
-		alwaysIdentified = false
-		
-		remoteDiscoveryScale = 0.001
-		discoveryScienceReward = 50
-	        identifyScienceReward = 50
-		
-		useAirDensity = False
-		distributionType = Spherical
-		
-		altUpperBound = 500000
-		altLowerBound = 260000
-		altPeak = 390000
-		altVariability = 10
-		altFalloffType = Linear
-		
-		latUpperBound = 30
-		latLowerBound = -30
-		latPeak = 0
-		latVariability = 1
-		latFalloffType = None
-	}
-	RESOURCEBAND
-	{
-		name = donkAreaRing
-		title = #LOC_SpaceDust_Band_Ring
-		
-		minAbundance = 4.10E-18
-		maxAbundance = 8.05E-18
-		
-		countScale = 20
-		rotateRate = 0.25
+		minAbundance = 0.0000038
+		maxAbundance = 0.0000072
 		
 		alwaysDiscovered = false
 		alwaysIdentified = false
 		
-		remoteDiscoveryScale = 0.001
-		discoveryScienceReward = 50
-	        identifyScienceReward = 50
+		remoteDiscoveryScale = 0.1
+		discoveryScienceReward = 15
+	    identifyScienceReward = 15
 		
-		useAirDensity = False
+		useAirDensity = True
+		densityCurve
+		{
+			key = 0 0
+			key = 1 1
+			key = 12 12
+		}
 		distributionType = Spherical
 		
-		altUpperBound = 1940000
-		altLowerBound = 1700000
-		altPeak = 1820000
+		altUpperBound = 32000
+		altLowerBound = -500
+		altPeak = 0
 		altVariability = 0
 		altFalloffType = Linear
 		
-		latUpperBound = 1
-		latLowerBound = -1
+		latUpperBound = 90
+		latLowerBound = -90
 		latPeak = 0
 		latVariability = 0
 		latFalloffType = None
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
 	resourceName = LqdHydrogen
-	body = Gurdamma
+	body = Ovin
 	
 	RESOURCEBAND
 	{
-		name = gurdammaExo
+		name = ovinExo
 		title = #LOC_SpaceDust_Band_Exosphere
 		
-		minAbundance = 1.11E-19
-		maxAbundance = 7.03E-20
+		minAbundance = 1.11E-21
+		maxAbundance = 7.03E-22
 		
 		countScale = 50
 		rotateRate = 1

--- a/SpaceDustNext/Definitions/Promised Worlds/Rosh.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Rosh.cfg
@@ -1,12 +1,100 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 {
-	resourceName = Oxidizer
-	body = Lapat
+	resourceName = LqdHe3
+	body = Rosh
 	
 	RESOURCEBAND
 	{
-		name = lapatAtmo
+		name = roshAtmo
 		title = #LOC_SpaceDust_Band_Atmosphere
+		
+		minAbundance = 0.0000000918
+		maxAbundance = 0.0000000918
+		
+		alwaysDiscovered = false
+		alwaysIdentified = false
+		
+		remoteDiscoveryScale = 0.1
+		discoveryScienceReward = 25
+	        identifyScienceReward = 25
+		
+		useAirDensity = True
+		densityCurve
+		{
+			key = 0 0
+			key = 1 1
+			key = 12 12
+		}
+		distributionType = Spherical
+		
+		altUpperBound = 10000
+		altLowerBound = -500
+		altPeak = 0
+		altVariability = 0
+		altFalloffType = Linear
+		
+		latUpperBound = 90
+		latLowerBound = -90
+		latPeak = 0
+		latVariability = 0
+		latFalloffType = None
+	}
+}
+
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+{
+	resourceName = LiquidFuel
+	body = Rosh
+	
+	RESOURCEBAND
+	{
+		name = roshAtmo
+		title = #LOC_SpaceDust_Band_Atmosphere
+		
+		minAbundance = 1.0125
+		maxAbundance = 1.05
+  		@minAbundance *= #$/refLqdMethane$
+		@maxAbundance *= #$/refLqdMethane$
+		
+		alwaysDiscovered = false
+		alwaysIdentified = false
+		
+		remoteDiscoveryScale = 0.1
+		discoveryScienceReward = 10
+	        identifyScienceReward = 10
+		
+		useAirDensity = True
+		densityCurve
+		{
+			key = 0 0
+			key = 1 1
+			key = 12 12
+		}
+		distributionType = Spherical
+		
+		altUpperBound = 10000
+		altLowerBound = -500
+		altPeak = 0
+		altVariability = 0
+		altFalloffType = Linear
+		
+		latUpperBound = 90
+		latLowerBound = -90
+		latPeak = 0
+		latVariability = 0
+		latFalloffType = None
+	}
+}
+
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+{
+	resourceName = LqdCO2
+	body = Rosh
+	
+	RESOURCEBAND
+	{
+		name = roshAtmo
+		title = #LOC_SpaceDust_Band_LowAtmosphere
 		
 		minAbundance = 0.000306
 		maxAbundance = 0.000306
@@ -27,7 +115,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		}
 		distributionType = Spherical
 		
-		altUpperBound = 97000
+		altUpperBound = 10000
 		altLowerBound = -500
 		altPeak = 0
 		altVariability = 0
@@ -39,90 +127,5 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
 		latVariability = 0
 		latFalloffType = None
 	}
-}
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
-{
-	resourceName = LqdNitrogen
-	body = Lapat
-	
-	RESOURCEBAND
-	{
-		name = lapatAtmo
-		title = #LOC_SpaceDust_Band_Atmosphere
-		
-		minAbundance = 1.0125
-		maxAbundance = 1.05
-		
-		alwaysDiscovered = false
-		alwaysIdentified = false
-		
-		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 10
-	        identifyScienceReward = 10
-		
-		useAirDensity = True
-		densityCurve
-		{
-			key = 0 0
-			key = 1 1
-			key = 12 12
-		}
-		distributionType = Spherical
-		
-		altUpperBound = 97000
-		altLowerBound = -500
-		altPeak = 0
-		altVariability = 0
-		altFalloffType = Linear
-		
-		latUpperBound = 90
-		latLowerBound = -90
-		latPeak = 0
-		latVariability = 0
-		latFalloffType = None
-	}
-}
-
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&DebdebSystem]
-{
-	resourceName = Water
-	body = Lapat
-	
-	RESOURCEBAND
-	{
-		name = lapatAtmo
-		title = #LOC_SpaceDust_Band_LowAtmosphere
-		
-		minAbundance = 0.0007
-		maxAbundance = 0.0007
-		
-		alwaysDiscovered = false
-		alwaysIdentified = false
-		
-		remoteDiscoveryScale = 0.1
-		discoveryScienceReward = 10
-	        identifyScienceReward = 10
-		
-		useAirDensity = True
-		densityCurve
-		{
-			key = 0 0
-			key = 1 1
-			key = 12 12
-		}
-		distributionType = Spherical
-		
-		altUpperBound = 97000
-		altLowerBound = -500
-		altPeak = 0
-		altVariability = 0
-		altFalloffType = Linear
-		
-		latUpperBound = 90
-		latLowerBound = -90
-		latPeak = 0
-		latVariability = 0
-		latFalloffType = None
-	}
 }


### PR DESCRIPTION
After v1.0.0 the MM name is PromisedWorlds, this replaces DebdebSystem references to ensure compatibility. Further changes will be required after we add the Tuun system, and we will ensure ModuleManager compatibility to easily detect systems.

Fixes #2 