### PR TITLE
Change PromisedWorlds to SystemDebdeb

### DIFF
--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Axod.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Axod.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdHe3
 	body = Axod
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdDeuterium
 	body = Axod
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdHydrogen
 	body = Axod
@@ -127,7 +127,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdDeuterium
 	body = Axod
@@ -170,7 +170,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdHydrogen
 	body = Axod
@@ -213,7 +213,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdMethane
 	body = Axod
@@ -256,7 +256,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdAmmonia
 	body = Axod
@@ -299,7 +299,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = Water
 	body = Axod

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Charr.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Charr.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
   resourceName = LqdHe3
   body = Charr
@@ -34,7 +34,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	latFalloffType = None
   }
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
   resourceName = Rock
   body = Charr
@@ -70,7 +70,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	latFalloffType = Linear
   }
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdCO2
 	body = Charr

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Debdeb.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Debdeb.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
   resourceName = LqdHydrogen
   body = Debdeb
@@ -64,7 +64,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	latFalloffType = None
   }
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
   resourceName = LqdHe3
   body = Debdeb
@@ -100,7 +100,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	latFalloffType = None
   }
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
   resourceName = LqdDeuterium
   body = Debdeb

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Donk.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Donk.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdCO2
 	body = Donk
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = ArgonGas
 	body = Donk
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = Antimatter
 	body = Donk

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Dorau.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Dorau.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdNitrogen
 	body = Dorau
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdCO2
 	body = Dorau
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdAmmonia
 	body = Dorau

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Glumo.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Glumo.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdHe3
 	body = Glumo
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdDeuterium
 	body = Glumo
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdHydrogen
 	body = Glumo
@@ -127,7 +127,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdHydrogen
 	body = Glumo
@@ -164,7 +164,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdDeuterium
 	body = Glumo
@@ -201,7 +201,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdMethane
 	body = Glumo
@@ -244,7 +244,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = Water
 	body = Glumo
@@ -287,7 +287,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = Antimatter
 	body = Glumo

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Gurdamma.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Gurdamma.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdCO2
 	body = Gurdamma
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdNitrogen
 	body = Gurdamma
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = Water
 	body = Gurdamma
@@ -126,7 +126,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 		latFalloffType = None
 	}
 }
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = Antimatter
 	body = Gurdamma
@@ -196,7 +196,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdHydrogen
 	body = Gurdamma

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Lapat.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Lapat.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = Oxidizer
 	body = Lapat
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdNitrogen
 	body = Lapat
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = Water
 	body = Lapat

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Merbel.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Merbel.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LiquidFuel
 	body = Merbel
@@ -43,7 +43,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdNitrogen
 	body = Merbel
@@ -86,7 +86,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdCO2
 	body = Merbel

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Ovin.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Ovin.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdCO2
 	body = Ovin
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdNitrogen
 	body = Ovin
@@ -84,7 +84,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = Water
 	body = Ovin
@@ -127,7 +127,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = ArgonGas
 	body = Ovin
@@ -170,7 +170,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdHydrogen
 	body = Ovin

--- a/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Rosh.cfg
+++ b/SpaceDustNext/Definitions/Promised Worlds/Debdeb System/Rosh.cfg
@@ -1,4 +1,4 @@
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdHe3
 	body = Rosh
@@ -41,7 +41,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LiquidFuel
 	body = Rosh
@@ -86,7 +86,7 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
 	}
 }
 
-SPACEDUST_RESOURCE:NEEDS[SpaceDust&PromisedWorlds]
+SPACEDUST_RESOURCE:NEEDS[SpaceDust&SystemDebdeb]
 {
 	resourceName = LqdCO2
 	body = Rosh


### PR DESCRIPTION
This allows detection of the dummy ModuleManager node on Promised Worlds 1.1.2 and beyond, so that the Debdeb patches will only be applied if the Debdeb system is installed.
I should have just called it DebdebSystem, but I didn't think about that and now it's shipped...
This will make SDN only apply Debdeb patches if Debdeb is installed for PW 1.1.2 and beyond.